### PR TITLE
allele column is now the last

### DIFF
--- a/workflows/singleVariantAssociation/association.R
+++ b/workflows/singleVariantAssociation/association.R
@@ -55,6 +55,7 @@ if(sum(gds.mac.filt)==0) {
 	print("Finished Association Step")
 	print(dim(assoc))
 	assoc <- cbind(snps.pos, assoc)
+	assoc = subset(assoc, select=c(1,3:length(colnames(assoc)),2))
 
 }
 ## save assoc object


### PR DESCRIPTION
This reorders the columns in the output assoc.RData to move the "allele" column to the end. This makes our metal workflow work as metal has trouble parsing csv's.